### PR TITLE
let the default envs for mviewerstudio except for MVIEWERSTUDIO_URL_P…

### DIFF
--- a/mviewer/ci/all-optional-values.yaml
+++ b/mviewer/ci/all-optional-values.yaml
@@ -112,9 +112,6 @@ mviewerstudio:
   podAnnotations:
     myapp: mviewer
   keepConfigFromKubernetes: true
-  extraEnv:
-  - name: FOO
-    value: BAR
   lifecycle:
     postStart:
       exec:

--- a/mviewer/templates/mviewerstudio-deployment.yaml
+++ b/mviewer/templates/mviewerstudio-deployment.yaml
@@ -61,20 +61,8 @@ spec:
         - name: http
           containerPort: 8000
           protocol: TCP
-        env:
-        - name: MVIEWERSTUDIO_URL_PATH_PREFIX
-          value: mviewerstudio
-        - name: CONF_PATH_FROM_MVIEWER
-          value: apps/drafts
-        - name: CONF_PUBLISH_PATH_FROM_MVIEWER
-          value: apps/published
-        - name: EXPORT_CONF_FOLDER
-          value: /home/apprunner/apps/drafts
-        - name: MVIEWERSTUDIO_PUBLISH_PATH
-          value: /home/apprunner/apps/published
-        - name: DEFAULT_ORG
-          value: no_org
         {{- with $webapp.extraEnv }}
+        env:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         resources:

--- a/mviewer/values.yaml
+++ b/mviewer/values.yaml
@@ -137,7 +137,10 @@ mviewerstudio:
   lifecycle: {}
   extraVolumes: []
   extraVolumeMounts: []
-  extraEnv: {}
+  # see https://github.com/mviewer/mviewerstudio/blob/master/docker/readme.md
+  extraEnv:
+  - name: MVIEWERSTUDIO_URL_PATH_PREFIX
+    value: mviewerstudio
   persistence:
     mviewerstudio_static_apps:
       annotations:


### PR DESCRIPTION
This removes all the custom envs except for MVIEWERSTUDIO_URL_PATH_PREFIX

Because the default behavior of mviewer is at apps/public and apps/store, so on.

@jeanpommier not sure why you did set all of these envs in your helm chart?